### PR TITLE
Fix dependency type in Dependabot configuration

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -21,7 +21,7 @@ updates:
       interval: daily
     groups:
       go-dev-deps:
-        dependency-type: direct
+        dependency-type: development
         update-types:
           - minor
           - patch


### PR DESCRIPTION
Update the dependency type for the `go-dev-deps` group from direct to development in the Dependabot configuration.