### PR TITLE
Revert npm version to 0.0.1 and update release-please config

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "chezroot",
-  "version": "0.1.1",
+  "version": "0.0.1",
   "type": "module",
   "private": true,
   "engines": {

--- a/release-please-config.json
+++ b/release-please-config.json
@@ -5,9 +5,6 @@
       "release-type": "go",
       "bump-minor-pre-major": true,
       "bump-patch-for-minor-pre-major": true,
-      "extra-files": [
-        "package.json"
-      ],
       "changelog-path": "CHANGELOG.md",
       "draft": false,
       "prerelease": false,


### PR DESCRIPTION
Revert the npm version to 0.0.1 and remove unnecessary configuration for release-please to prevent updates to package.json.