### PR TITLE
Add homebrew-tap configuration to release-please

### DIFF
--- a/release-please-config.json
+++ b/release-please-config.json
@@ -3,6 +3,7 @@
   "packages": {
     ".": {
       "release-type": "go",
+      "homebrew-tap": "main-branch/homebrew-tap",
       "bump-minor-pre-major": true,
       "bump-patch-for-minor-pre-major": true,
       "changelog-path": "CHANGELOG.md",


### PR DESCRIPTION
Include homebrew-tap in the release-please configuration to streamline updates.