### PR TITLE
Update .gitignore and Makefile for husky directory cleanup

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -41,3 +41,5 @@ yarn-error.log*
 
 # IDEs
 .idea/ # JetBrains (GoLand, etc.)
+
+.husky/_

--- a/Makefile
+++ b/Makefile
@@ -98,8 +98,11 @@ clean:
 	@rm -f chezroot
 	@rm -rf ./bin
 	@rm -f coverage.*
+	@rm -f *.out
+	@rm -rf ./dist
 
 # clean-all: Remove all generated files, including local dependencies
 clean-all: clean
 	@echo "--> Clobbering all dependencies..."
 	@rm -rf ./node_modules
+	@rm -rf ./.husky/_


### PR DESCRIPTION
Include the husky directory in the clean tasks of the Makefile and update .gitignore accordingly.