### PR TITLE
Refactor: Go standard project structure

### DIFF
--- a/internal/executor/executor.go
+++ b/internal/executor/executor.go
@@ -1,5 +1,4 @@
-package main
-package main
+package executor
 
 import (
 	"errors"
@@ -27,7 +26,7 @@ func (r *RealCommandRunner) Run(name string, args []string, stdin io.Reader, std
 
 	err := cmd.Run()
 
-	package main
+	exitCode := 0
 	if err != nil {
 		var exitErr *exec.ExitError
 		if errors.As(err, &exitErr) {
@@ -43,6 +42,16 @@ func (r *RealCommandRunner) Run(name string, args []string, stdin io.Reader, std
 
 // defaultRunner is the global default command runner.
 var defaultRunner CommandRunner = &RealCommandRunner{}
+
+// GetDefaultRunner returns the current default runner (for testing).
+func GetDefaultRunner() CommandRunner {
+	return defaultRunner
+}
+
+// SetDefaultRunner sets the default runner (for testing).
+func SetDefaultRunner(runner CommandRunner) {
+	defaultRunner = runner
+}
 
 // ExecuteChezmoi runs chezmoi in a subprocess with the given arguments.
 // If useSudo is true, it prefixes the command with "sudo".

--- a/internal/executor/executor.go
+++ b/internal/executor/executor.go
@@ -1,4 +1,5 @@
 package main
+package main
 
 import (
 	"errors"
@@ -26,8 +27,7 @@ func (r *RealCommandRunner) Run(name string, args []string, stdin io.Reader, std
 
 	err := cmd.Run()
 
-	// Extract the exit code
-	exitCode := 0
+	package main
 	if err != nil {
 		var exitErr *exec.ExitError
 		if errors.As(err, &exitErr) {

--- a/internal/executor/executor_test.go
+++ b/internal/executor/executor_test.go
@@ -1,4 +1,4 @@
-package main
+package executor
 
 import (
 	"bytes"

--- a/internal/runner/real_runner_test.go
+++ b/internal/runner/real_runner_test.go
@@ -1,4 +1,5 @@
 package main
+package main
 
 import (
 	"bytes"

--- a/internal/runner/real_runner_test.go
+++ b/internal/runner/real_runner_test.go
@@ -1,14 +1,15 @@
-package main
-package main
+package runner
 
 import (
 	"bytes"
 	"testing"
+
+	"github.com/main-branch/chezroot/internal/executor"
 )
 
 // TestRealCommandRunner_Success verifies successful execution with output.
 func TestRealCommandRunner_Success(t *testing.T) {
-	runner := &RealCommandRunner{}
+	runner := &executor.RealCommandRunner{}
 	var stdout, stderr bytes.Buffer
 
 	exitCode, err := runner.Run("bash", []string{"-c", "echo hi"}, nil, &stdout, &stderr)
@@ -38,7 +39,7 @@ func TestRealCommandRunner_Success(t *testing.T) {
 
 // TestRealCommandRunner_NonZeroExit verifies non-zero exit captures exit code and yields nil error.
 func TestRealCommandRunner_NonZeroExit(t *testing.T) {
-	runner := &RealCommandRunner{}
+	runner := &executor.RealCommandRunner{}
 	var stdout, stderr bytes.Buffer
 	exitCode, err := runner.Run("bash", []string{"-c", "exit 7"}, nil, &stdout, &stderr)
 	if err != nil {
@@ -51,7 +52,7 @@ func TestRealCommandRunner_NonZeroExit(t *testing.T) {
 
 // TestRealCommandRunner_CommandNotFound verifies handling of an execution error (command not found).
 func TestRealCommandRunner_CommandNotFound(t *testing.T) {
-	runner := &RealCommandRunner{}
+	runner := &executor.RealCommandRunner{}
 	var stdout, stderr bytes.Buffer
 	exitCode, err := runner.Run("___no_such_command___", nil, nil, &stdout, &stderr)
 	if err == nil {

--- a/main.go
+++ b/main.go
@@ -2,13 +2,15 @@ package main
 
 import (
 	"os"
+
+	"github.com/main-branch/chezroot/internal/executor"
 )
 
 // run is an extraction of main logic for testability. It returns the exit code
 // that should be used by the process. Any error from ExecuteChezmoi is mapped
 // to exit code 1 after writing its message to stderr.
 func run(args []string) int {
-	exitCode, err := ExecuteChezmoi(args, false)
+	exitCode, err := executor.ExecuteChezmoi(args, false)
 	if err != nil {
 		os.Stderr.WriteString(err.Error() + "\n")
 		return 1

--- a/main_exit_test.go
+++ b/main_exit_test.go
@@ -4,6 +4,8 @@ import (
 	"io"
 	"os"
 	"testing"
+
+	"github.com/main-branch/chezroot/internal/executor"
 )
 
 // mockExitRunner implements CommandRunner to drive main() paths.
@@ -34,7 +36,11 @@ func captureStderr(t *testing.T) (restore func() string) {
 
 // TestMainFunction_Success ensures main invokes exitFunc with underlying exit code.
 func TestMainFunction_Success(t *testing.T) {
-	defaultRunner = &mockExitRunner{code: 0, err: nil}
+	// Save original runner
+	originalRunner := executor.GetDefaultRunner()
+	defer executor.SetDefaultRunner(originalRunner)
+
+	executor.SetDefaultRunner(&mockExitRunner{code: 0, err: nil})
 	var got int
 	exitFunc = func(c int) { got = c }
 	defer func() { exitFunc = os.Exit }()
@@ -46,7 +52,11 @@ func TestMainFunction_Success(t *testing.T) {
 
 // TestMainFunction_Error ensures error path maps to exit code 1 and writes stderr.
 func TestMainFunction_Error(t *testing.T) {
-	defaultRunner = &mockExitRunner{code: -1, err: errSentinel}
+	// Save original runner
+	originalRunner := executor.GetDefaultRunner()
+	defer executor.SetDefaultRunner(originalRunner)
+
+	executor.SetDefaultRunner(&mockExitRunner{code: -1, err: errSentinel})
 	var got int
 	exitFunc = func(c int) { got = c }
 	defer func() { exitFunc = os.Exit }()

--- a/main_test.go
+++ b/main_test.go
@@ -3,6 +3,8 @@ package main
 import (
 	"io"
 	"testing"
+
+	"github.com/main-branch/chezroot/internal/executor"
 )
 
 // mockRunnerMinimal is a lightweight mock for testing run().
@@ -17,7 +19,11 @@ func (m *mockRunnerMinimal) Run(_ string, _ []string, _ io.Reader, _, _ io.Write
 
 // TestRun_Success covers the success path through run().
 func TestRun_Success(t *testing.T) {
-	defaultRunner = &mockRunnerMinimal{code: 0, err: nil}
+	// Save original runner
+	originalRunner := executor.GetDefaultRunner()
+	defer executor.SetDefaultRunner(originalRunner)
+
+	executor.SetDefaultRunner(&mockRunnerMinimal{code: 0, err: nil})
 	code := run([]string{"--version"})
 	if code != 0 {
 		// If chezmoi returned 0 we expect pass-through.
@@ -27,7 +33,11 @@ func TestRun_Success(t *testing.T) {
 
 // TestRun_Error covers the error path mapping to exit code 1.
 func TestRun_Error(t *testing.T) {
-	defaultRunner = &mockRunnerMinimal{code: -1, err: errSentinel}
+	// Save original runner
+	originalRunner := executor.GetDefaultRunner()
+	defer executor.SetDefaultRunner(originalRunner)
+
+	executor.SetDefaultRunner(&mockRunnerMinimal{code: -1, err: errSentinel})
 	code := run([]string{"--version"})
 	if code != 1 {
 		// Error should map to 1 irrespective of -1 sentinel.


### PR DESCRIPTION
- Move executor.go and executor_test.go to internal/executor
- Move real_runner_test.go to internal/runner
- Remove duplicates from root
- Update package and import paths

This PR reorganizes the project to follow Go conventions, keeping main.go in root and moving supporting code/tests to internal/.